### PR TITLE
Api limits

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Chris Vale <crispywalrus@gmail.com>
 Adam Vandenberg <flangy@gmail.com>
 Kenneth Reitz <me@kennethreitz.com>
 Daniel Greenfeld <pydanny@gmail.com>
+Jeremy Dunck <jdunck@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -38,15 +38,20 @@ by doing the following,::
     $ python setup.py build
     # python setup.py install # as root
 
-Creating a request
+Creating a client
 ------------------
 
     >>> from github2.client import Github
     >>> github = Github(username="ask", api_token=".......")
 
-Or for an unauthenticated connection
+Or for an unauthenticated connection:
 
     >>> github = Github()
+
+API calls are limited by github.com to 1 per second by default.  To have the Github client enforce this and avoid rate limit errors, pass requests_per_second in:
+
+  >>> from github2.client import Github
+  >>> github = Github(username="ask", api_token=".......", requests_per_second=1)
 
 Users
 =====

--- a/github2/client.py
+++ b/github2/client.py
@@ -6,10 +6,29 @@ from github2.commits import Commits
 
 class Github(object):
 
-    def __init__(self, username=None, api_token=None, debug=False):
+    def __init__(self, username=None, api_token=None, debug=False,
+        requests_per_second=None):
+        """
+        An interface to GitHub's API:
+            http://develop.github.com/
+        
+        Params:
+            `username` is your own GitHub username.
+    
+            `api_token` can be found here (while logged in as that user):
+                https://github.com/account
+    
+            `requests_per_second` is a float indicating the API rate limit
+                you're operating under (1 per second per GitHub at the moment),
+                or None to disable delays. 
+
+                The default is to disable delays (for backwards compatibility).
+        """
+        
         self.debug = debug
         self.request = GithubRequest(username=username, api_token=api_token,
-                                     debug=self.debug)
+                                     debug=self.debug, 
+                                     requests_per_second=requests_per_second)
         self.issues = Issues(self.request)
         self.users = Users(self.request)
         self.repos = Repositories(self.request)

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -2,6 +2,7 @@
 import unittest
 
 from github2.issues import Issue
+from github2.client import Github
 
 
 class ReprTests(unittest.TestCase):
@@ -11,3 +12,23 @@ class ReprTests(unittest.TestCase):
         """Issues can have non-ASCII characters in the title."""
         i = Issue(title = u'abcdé')
         self.assertEqual(str, type(repr(i)))
+
+
+class RateLimits(unittest.TestCase):
+    """
+    How should we handle actual API calls such that tests can run?
+    Perhaps the library should support a ~/.python_github2.conf from which to get the auth?
+    """
+    def test_delays(self):
+        import datetime, time
+        USERNAME=''
+        API_KEY=''
+        client = Github(username=USERNAME, api_token=API_KEY, 
+            requests_per_second=.5)
+        client.users.show('defunkt')
+        start = datetime.datetime.now()
+        client.users.show('mojombo')
+        end = datetime.datetime.now()
+        self.assertGreaterEqual((end-start).total_seconds(), 2.0, 
+            "Expected .5 reqs per second to require a 2 second delay between calls.")
+        


### PR DESCRIPTION
I added a param to the Github class which enforces rate limits by sleeping the thread if requests are occurring too fast.

It's backwards compatible because delays only happen if requests_per_second is passed in.  Includes a test, some docstrings, and an updated README.
