### PR TITLE
Failed to add a label with a space to an issue 

### DIFF
--- a/github2/request.py
+++ b/github2/request.py
@@ -11,7 +11,7 @@ try:
     from urlparse import parse_qs
 except ImportError:
     from cgi import parse_qs
-from urllib import urlencode
+from urllib import urlencode, quote
 
 GITHUB_URL = "https://github.com"
 
@@ -87,7 +87,7 @@ class GithubRequest(object):
                 time.sleep(duration)
 
         extra_post_data = extra_post_data or {}
-        url = "/".join([self.url_prefix, path])
+        url = "/".join([self.url_prefix, quote(path)])
         result = self.raw_request(url, extra_post_data, method=method)
 
         if self.delay:


### PR DESCRIPTION
The URL wasn't escaped properly when labels included a space "This is a label" during the add_label request.
