### PR TITLE
Modified MANIFEST.in. It wasn't installing on Windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ recursive-include doc *.rst
 include doc/conf.py
 include doc/Makefile
 include doc/.templates/layout.html
-prune doc/.build/
+prune doc/.build
 
 include tests/*.py
 recursive-include tests/data *


### PR DESCRIPTION
https://github.com/broderboy/python-github2/commit/48d85d517b4e51652217b71b264c866caa5ca874

I'm not sure why git put that as a full file change
line changed: prune doc/.build

Thanks

Original Error: 
running install
running bdist_egg
running egg_info
writing requirements to github2.egg-info\requires.txt
writing github2.egg-info\PKG-INFO
writing top-level names to github2.egg-info\top_level.txt
writing dependency_links to github2.egg-info\dependency_links.txt
writing requirements to github2.egg-info\requires.txt
writing github2.egg-info\PKG-INFO
writing top-level names to github2.egg-info\top_level.txt
writing dependency_links to github2.egg-info\dependency_links.txt
reading manifest file 'github2.egg-info\SOURCES.txt'
reading manifest template 'MANIFEST.in'
Traceback (most recent call last):
  File ".\setup.py", line 46, in <module>
    "Topic :: Software Development :: Libraries",
  File "C:\Python26\lib\distutils\core.py", line 152, in setup
    dist.run_commands()
  File "C:\Python26\lib\distutils\dist.py", line 975, in run_commands
    self.run_command(cmd)
  File "C:\Python26\lib\distutils\dist.py", line 995, in run_command
    cmd_obj.run()
  File "C:\Python26\lib\site-packages\distribute-0.6.10-py2.6.egg\setuptools\command\install.py", line 73, in run
    self.do_egg_install()
  File "C:\Python26\lib\site-packages\distribute-0.6.10-py2.6.egg\setuptools\command\install.py", line 93, in do_egg_install
    self.run_command('bdist_egg')
  File "C:\Python26\lib\distutils\cmd.py", line 333, in run_command
    self.distribution.run_command(command)
  File "C:\Python26\lib\distutils\dist.py", line 995, in run_command
    cmd_obj.run()
  File "C:\Python26\lib\site-packages\distribute-0.6.10-py2.6.egg\setuptools\command\bdist_egg.py", line 167, in run
    self.run_command("egg_info")
  File "C:\Python26\lib\distutils\cmd.py", line 333, in run_command
    self.distribution.run_command(command)
  File "C:\Python26\lib\distutils\dist.py", line 995, in run_command
    cmd_obj.run()
  File "C:\Python26\lib\site-packages\distribute-0.6.10-py2.6.egg\setuptools\command\egg_info.py", line 179, in run
    self.find_sources()
  File "C:\Python26\lib\site-packages\distribute-0.6.10-py2.6.egg\setuptools\command\egg_info.py", line 254, in find_sources
    mm.run()
  File "C:\Python26\lib\site-packages\distribute-0.6.10-py2.6.egg\setuptools\command\egg_info.py", line 310, in run
    self.read_template()
  File "C:\Python26\lib\site-packages\distribute-0.6.10-py2.6.egg\setuptools\command\sdist.py", line 204, in read_template
    _sdist.read_template(self)
  File "C:\Python26\lib\distutils\command\sdist.py", line 336, in read_template
    self.filelist.process_template_line(line)
  File "C:\Python26\lib\distutils\filelist.py", line 129, in process_template_line
    (action, patterns, dir, dir_pattern) = self._parse_template_line(line)
  File "C:\Python26\lib\distutils\filelist.py", line 112, in _parse_template_line
    dir_pattern = convert_path(words[1])
  File "C:\Python26\lib\distutils\util.py", line 201, in convert_path
    raise ValueError, "path '%s' cannot end with '/'" % pathname
ValueError: path 'doc/.build/' cannot end with '/'
