### PR TITLE
Getting "currently logged in user data" when using access_token

### DIFF
--- a/doc/api/client.rst
+++ b/doc/api/client.rst
@@ -19,6 +19,10 @@ access token::
 
     >>> github = Github(access_token="........")
 
+.. note::
+   You can retrieve the user data for an OAuth authenticated user with
+   ``github.users.show("")``.
+
 Or for an unauthenticated connection::
 
     >>> github = Github()

--- a/github2/repositories.py
+++ b/github2/repositories.py
@@ -53,16 +53,18 @@ class Repositories(GithubCommand):
         return self.get_values("pushable", filter="repositories", datatype=Repository)
 
 
-    def list(self, for_user=None):
+    def list(self, user=None):
         """Return a list of all repositories for a user.
 
-        If no user is given, repositoris for the currently logged in user are
-        returned.
+        .. deprecated: 0.4.0
+           Previous releases would attempt to display repositories for the
+           logged-in user when ``user`` wasn't supplied.  This functionality is
+           brittle and will be removed in a future release!
 
-        :param str for_user: optional Github user name to list repositories for
+        :param str user: Github user name to list repositories for
         """
-        for_user = for_user or self.request.username
-        return self.get_values("show", for_user, filter="repositories",
+        user = user or self.request.username
+        return self.get_values("show", user, filter="repositories",
                                datatype=Repository)
 
     def watch(self, project):

--- a/github2/users.py
+++ b/github2/users.py
@@ -55,6 +55,9 @@ class Users(GithubCommand):
     def show(self, username):
         """Get information on Github user
 
+        if ``username`` is ``None`` or an empty string information for the
+        currently authenticated user is returned.
+
         :param str username: Github user name
         """
         return self.get_value("show", username, filter="user", datatype=User)


### PR DESCRIPTION
e.g. github.repos.list() specifies following behaviour: "If no user is given, repositoris for the currently logged in user are returned."

However this works only if using username for authentication but with OAuth2 access token following error is thrown:

RuntimeError: unexpected response from github.com 401: '{"error":"api route not recognized"}'

Workaround for this is to request current username using following pattern:

user = github.users.show("")

and then use returned username as an parameter for list(). 

I guess we need to populate the internal username in a constructor via show API when username is not given or is there better solution?
