### PR TITLE
pull-requests - raise TypeError and better docs

### DIFF
--- a/github2/pull_requests.py
+++ b/github2/pull_requests.py
@@ -67,6 +67,10 @@ class PullRequests(GithubCommand):
             post_data["title"] = title
             if body:
                 post_data["body"] = body
+        else:
+            raise TypeError("You must either specify a title for the "
+                            "pull request or an issue number to which the "
+                            "pull request should be attached.")
         pull_request_data = [("pull[%s]" % k, v) for k, v in post_data.items()]
         return self.get_value(project, post_data=dict(pull_request_data),
             filter="pull", datatype=PullRequest)


### PR DESCRIPTION
I spent a good amount of time trying to figure out the proper way to call the PullRequests.create method. I'm raising a TypeError because if the user doesn't specify a title, a NoneType error will be raised later. 

Maybe it would be a good idea to also write an example of the call with the format for the project name. For now I've just tried to make it more obvious which project the 'project' parameter refers to.
