### PR TITLE
Handle unrecognized HTTP error codes from API

### DIFF
--- a/github2/request.py
+++ b/github2/request.py
@@ -88,7 +88,7 @@ class HttpError(RuntimeError):
         self.message = message
         self.content = content
         self.code = code
-        if code and responses:
+        if responses and code in responses:
             self.code_reason = responses[code]
         else:
             self.code_reason = ""


### PR DESCRIPTION
I tried to create a pull request that already existed and Github returned an HTTP 422 error. This caused a KeyError to be raised when trying to parse the response.

This change makes it simply attach a blank message to the HTTPError.
