### PR TITLE
Added support for Github Enterprise

### DIFF
--- a/doc/api/client.rst
+++ b/doc/api/client.rst
@@ -50,4 +50,12 @@ given, is 8080::
     >>> github = Github(username="ask", api_token=".......",
     ...                 proxy_host="my.proxy.com", proxy_port=9000)
 
+You may specify a Github Enterprise URL by passing in the ``github_url``
+setting. If you do not specify ``github_url``, requests will be made
+to https://github.com.
+
+    >>> from github2.client import Github
+    >>> github = Github(username="modocache", api_token=".......",
+    ...                 github_url="http://git.gree-dev.net/")
+
 .. _OAuth service: http://develop.github.com/p/oauth.html

--- a/github2/client.py
+++ b/github2/client.py
@@ -12,7 +12,7 @@ class Github(object):
 
     def __init__(self, username=None, api_token=None, requests_per_second=None,
                  access_token=None, cache=None, proxy_host=None,
-                 proxy_port=8080):
+                 proxy_port=8080, github_url=None):
         """
         An interface to GitHub's API:
             http://develop.github.com/
@@ -44,7 +44,8 @@ class Github(object):
                                      requests_per_second=requests_per_second,
                                      access_token=access_token, cache=cache,
                                      proxy_host=proxy_host,
-                                     proxy_port=proxy_port)
+                                     proxy_port=proxy_port,
+                                     github_url=github_url)
         self.issues = Issues(self.request)
         self.users = Users(self.request)
         self.repos = Repositories(self.request)

--- a/github2/request.py
+++ b/github2/request.py
@@ -34,7 +34,7 @@ import httplib2
 
 
 #: Hostname for API access
-GITHUB_URL = "https://github.com"
+DEFAULT_GITHUB_URL = "https://github.com"
 
 #: Logger for requests module
 LOGGER = logging.getLogger('github2.request')
@@ -96,7 +96,6 @@ class HttpError(RuntimeError):
 
 
 class GithubRequest(object):
-    github_url = GITHUB_URL
     url_format = "%(github_url)s/api/%(api_version)s/%(api_format)s"
     api_version = "v2"
     api_format = "json"
@@ -104,7 +103,8 @@ class GithubRequest(object):
 
     def __init__(self, username=None, api_token=None, url_prefix=None,
                  requests_per_second=None, access_token=None,
-                 cache=None, proxy_host=None, proxy_port=None):
+                 cache=None, proxy_host=None, proxy_port=None,
+                 github_url=None):
         """Make an API request.
 
         :see: :class:`github2.client.Github`
@@ -113,6 +113,10 @@ class GithubRequest(object):
         self.api_token = api_token
         self.access_token = access_token
         self.url_prefix = url_prefix
+        if github_url is None:
+            self.github_url = DEFAULT_GITHUB_URL
+        else:
+            self.github_url = github_url
         if requests_per_second is None:
             self.delay = 0
         else:


### PR DESCRIPTION
I added support for Github Enterprise by allowing users to pass a parameter specifying the host to send requests to. Enterprise environments can exist on URLs besides https://github.com .

Thanks a lot for this project, and let me know if there's anything I could do to improve this request.
