### PR TITLE
docs: Fix a few typos

### DIFF
--- a/github2/client.py
+++ b/github2/client.py
@@ -107,7 +107,7 @@ class Github(object):
         return blob.get("blob")
 
     def get_tree(self, project, tree_sha):
-        """Get tree information for a specifc tree.
+        """Get tree information for a specific tree.
 
         :param str project: GitHub project
         :param str tree_sha: object ID of tree

--- a/github2/request.py
+++ b/github2/request.py
@@ -113,7 +113,7 @@ class GithubError(Exception):
 
 class HttpError(RuntimeError):
 
-    """A HTTP error occured when making a request to the GitHub API."""
+    """A HTTP error occurred when making a request to the GitHub API."""
 
     def __init__(self, message, content, code):
         """Create a HttpError exception.


### PR DESCRIPTION
There are small typos in:
- github2/client.py
- github2/request.py

Fixes:
- Should read `specific` rather than `specifc`.
- Should read `occurred` rather than `occured`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md